### PR TITLE
feat: 노드 구조화

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,10 +52,10 @@ async def get_canvas(request: Request):
         "request": request,
         "diagram": {
             "nodes": [
-                {"id": "vert1", "label": "Hello1"},
-                {"id": "vert2", "label": "Hello2"},
-                {"id": "vert3", "label": "Hello3"},
-                {"id": "vert4", "label": "Hello4"},
+                {"id": "vert1", "name": "Hello1"},
+                {"id": "vert2", "name": "Hello2"},
+                {"id": "vert3", "name": "Hello3"},
+                {"id": "vert4", "name": "Hello4"},
             ],
             "edges": [
                 {"source": "vert1", "target": "vert2"},

--- a/static/canvas/css/canvas.css
+++ b/static/canvas/css/canvas.css
@@ -46,7 +46,7 @@ button:active {
   margin: 1rem;
 }
 
-.controller-panel-header {
+#controller-panel-header {
   display: flex;
   justify-content: end;
   align-items: center;

--- a/static/canvas/js/index.js
+++ b/static/canvas/js/index.js
@@ -9,11 +9,11 @@ function createNode() {
   const [diagram, setDiagram] = useState("diagram");
 
   const id = createId();
-  const label = `새로운 노드(${createRandomString(3)})`;
+  const name = `새로운 노드(${createRandomString(3)})`;
 
   setDiagram({
     ...diagram,
-    nodes: [...diagram.nodes, { id, label }],
+    nodes: [...diagram.nodes, { id, name }],
   });
 }
 

--- a/static/canvas/js/render-canvas.js
+++ b/static/canvas/js/render-canvas.js
@@ -15,7 +15,7 @@ function draw(diagram) {
 
   diagram.nodes?.forEach((node) => {
     mermaidText += `
-      ${node.id}["${node.label}"]
+      ${node.id}["${node.name}"]
     `;
   });
   diagram.edges?.forEach((edge) => {

--- a/static/canvas/js/render-controller-panel.js
+++ b/static/canvas/js/render-controller-panel.js
@@ -15,7 +15,7 @@ function renderNormalNodePanel(node) {
   panel.innerHTML = `
     <h2>Node</h2>
     <p>Node ID: ${node.id}</p>
-    <p>Node label: ${node.label}</p>
+    <p>Node name: ${node.name}</p>
   `;
 }
 

--- a/static/canvas/types/controller-panel.d.ts
+++ b/static/canvas/types/controller-panel.d.ts
@@ -1,5 +1,5 @@
 /// <reference path="./state.d.ts" />
 
-type RenderNormalNodePanelFn = (node: DataNode) => void;
+type RenderNormalNodePanelFn = (node: BaseNode) => void;
 
 type RenderControllerPanelFn = StateChangeListener<"selectedNode">;

--- a/static/canvas/types/diagram.d.ts
+++ b/static/canvas/types/diagram.d.ts
@@ -1,13 +1,13 @@
-/// <reference path="./node.d.ts" />
+/// <reference path="./nodes/common.d.ts" />
 
 type Edge = {
-  from: DataNode;
-  to: DataNode;
+  from: BaseNode;
+  to: BaseNode;
 };
 
 type WorkflowGraph = {
-  nodes: DataNode[];
+  nodes: BaseNode[];
   edges: Edge[];
 };
 
-type OnNodeClickedListener = (node: DataNode) => void;
+type OnNodeClickedListener = (node: BaseNode) => void;

--- a/static/canvas/types/node.d.ts
+++ b/static/canvas/types/node.d.ts
@@ -1,4 +1,0 @@
-type DataNode = {
-  id: string;
-  label: string;
-};

--- a/static/canvas/types/nodes/common.d.ts
+++ b/static/canvas/types/nodes/common.d.ts
@@ -1,0 +1,14 @@
+declare enum NodeType {
+  DRAFT = "DRAFT",
+  DATA = "DATA",
+  TRANSFORMER = "TRANSFORMER",
+  PRESENTATION = "PRESENTATION",
+}
+
+type BaseNodeId = string;
+
+type BaseNode = {
+  id: BaseNodeId;
+  name: string;
+  type: NodeType;
+};

--- a/static/canvas/types/nodes/data.d.ts
+++ b/static/canvas/types/nodes/data.d.ts
@@ -1,0 +1,9 @@
+/// <reference path="./common.d.ts" />
+
+type DataNode = BaseNode & {
+  type: NodeType.DATA;
+};
+
+type LoadFileNode = BaseNode & {
+  filePath: string;
+};

--- a/static/canvas/types/nodes/draft.d.ts
+++ b/static/canvas/types/nodes/draft.d.ts
@@ -1,0 +1,5 @@
+/// <reference path="./common.d.ts" />
+
+type DraftNode = BaseNode & {
+  type: NodeType.DRAFT;
+};

--- a/static/canvas/types/nodes/presentation.d.ts
+++ b/static/canvas/types/nodes/presentation.d.ts
@@ -2,6 +2,7 @@
 
 type PresentationNode = BaseNode & {
   type: NodeType.PRESENTATION;
+  from: BaseNodeId;
 };
 
 type SaveToFileNode = BaseNode & {

--- a/static/canvas/types/nodes/presentation.d.ts
+++ b/static/canvas/types/nodes/presentation.d.ts
@@ -1,0 +1,9 @@
+/// <reference path="./common.d.ts" />
+
+type PresentationNode = BaseNode & {
+  type: NodeType.PRESENTATION;
+};
+
+type SaveToFileNode = BaseNode & {
+  filePath: string;
+};

--- a/static/canvas/types/nodes/transformer.d.ts
+++ b/static/canvas/types/nodes/transformer.d.ts
@@ -1,0 +1,15 @@
+/// <reference path="./common.d.ts" />
+
+declare enum TransformAction {
+  FILL_WITH_ZERO = "FILL_WITH_ZERO",
+}
+
+type DataTransformerNode = BaseNode & {
+  type: NodeType.TRANSFORMER;
+  action: TransformAction;
+  from: BaseNodeId;
+};
+
+type FillMissingValueWithZeroTransformerNode = DataTransformerNode & {
+  action: TransformAction.FILL_WITH_ZERO;
+};

--- a/static/canvas/types/state.d.ts
+++ b/static/canvas/types/state.d.ts
@@ -2,7 +2,7 @@
 
 type State = {
   diagram: WorkflowGraph;
-  selectedNode: DataNode | null;
+  selectedNode: BaseNode | null;
 };
 
 type StateChangeListener<K extends keyof State> = (newState: State[K]) => void;
@@ -11,6 +11,6 @@ type StateChangeListenerMap = {
   [K in keyof State]: Array<StateChangeListener<K>>;
 };
 
-function UseStateFn<K extends keyof State>(
+declare function UseStateFn<K extends keyof State>(
   key: K
 ): [State[K], (newState: State[K]) => void];


### PR DESCRIPTION
- 각 노드을 구조화합니다.
    - `label`을 `name`으로 변경하였습니다.
    - 공통 프로퍼티 `type`이 추가됩니다.
        - `DRAFT`: 새로 생성된 노드이며 아무 데이터도 갖지 않습니다.
        - `DATA`: 데이터를 자체적으로 갖는 노드입니다. 현재는 파일 불러오기 노드가 존재합니다.
        - `TRANSFORMER`: 데이터를 input 1 : output 1로 변환시키는 노드입니다. 현재는 결측치 0으로 채우기 노드가 존재합니다.
        - `PRESENTATION`: 데이터를 표현하는 노드입니다. leaf 노드이며 다른 노드가 해당 노드를 참조할 수 없습니다. 현재는 파일로 저장 노드가 존재합니다.
        - input N : output 1, input 1 : output N, input N : output M 하는 노드는 이후 설계 예정이며 `TRANSFORMER`와는 다른 이름을 갖지 않을까 싶습니다.
- 겸사겸사 CSS 관련 문제도 해결합니다.