### PR TITLE
feat: 노드 변경 및 파일 선택 구현

### DIFF
--- a/static/canvas/css/canvas.css
+++ b/static/canvas/css/canvas.css
@@ -75,3 +75,15 @@ button:active {
   width: 100%;
   margin-bottom: 1rem;
 }
+
+input[type="file"] {
+  display: none;
+}
+
+.input-file-custom-button {
+  display: inline-block;
+  padding: 6px 12px;
+  cursor: pointer;
+  border: #888 1px solid;
+  border-radius: 4px;
+}

--- a/static/canvas/js/controller-panel/html-builder.js
+++ b/static/canvas/js/controller-panel/html-builder.js
@@ -1,5 +1,8 @@
 /// <reference path="../../types/controller-panel.d.ts" />
 
+import { createId } from "../util.js";
+import { InputController } from "./input-controller.js";
+
 export class ControllerPanelHtmlBuilder {
   constructor() {
     /** @type {ControllerPanelHtmlElement[]} */
@@ -26,10 +29,36 @@ export class ControllerPanelHtmlBuilder {
   }
 
   /**
-   * @returns {string}
+   * @param {string} label
+   * @param {string[]} options
+   * @param {InputController} controller
+   * @returns {this}
    */
-  build() {
-    return this.contents
+  select(label, options, controller) {
+    const newId = createId();
+    this.contents.push({ id: newId, type: "select", label, options });
+    controller.attach(newId);
+    return this;
+  }
+
+  /**
+   * @param {string} label
+   * @param {File | null} file
+   * @param {InputController} controller
+   * @returns {this}
+   */
+  file(label, file, controller) {
+    const newId = createId();
+    this.contents.push({ id: newId, type: "file", label, file });
+    controller.attach(newId);
+    return this;
+  }
+
+  /**
+   * @param {HTMLElement} container
+   */
+  build(container) {
+    const ui = this.contents
       .map((content) => {
         switch (content.type) {
           case "title":
@@ -44,9 +73,39 @@ export class ControllerPanelHtmlBuilder {
                 <label>${content.label}</label><span>${content.value}</span>
               </div>
             `;
+          case "select":
+            return `
+              <div class="controller-panel-kv-element">
+                <label>${content.label}</label>
+                <select id="${content.id}">
+                  ${content.options
+                    .map(
+                      (option) => `<option value="${option}">${option}</option>`
+                    )
+                    .join("\n")}
+                </select>
+              </div>
+            `;
+          case "file":
+            return `
+              <div class="controller-panel-kv-element">
+                <label>${content.label}</label>
+                <label class="input-file-custom-button">
+                  <input id="${content.id}" type="file">
+                  ${content.file ? content.file.name : "파일 선택"}
+                </label>
+              </div>
+            `;
         }
       })
       .join("\n");
+
+    container.innerHTML = ui;
+
+    this.contents.forEach((content) => {
+      // UI 생성 후 후처리 필요 시 사용
+      // ex) event listener
+    });
   }
 
   static builder() {

--- a/static/canvas/js/controller-panel/index.js
+++ b/static/canvas/js/controller-panel/index.js
@@ -1,7 +1,8 @@
 /// <reference path="../../types/controller-panel.d.ts" />
 
-import { registerStateChangeListener } from "../state.js";
+import { registerStateChangeListener, useState } from "../state.js";
 import { ControllerPanelHtmlBuilder } from "./html-builder.js";
+import { InputController } from "./input-controller.js";
 
 /**
  * @param {DraftNode} node
@@ -12,11 +13,84 @@ function renderDraftNodePanel(node) {
     return;
   }
 
-  panel.innerHTML = ControllerPanelHtmlBuilder.builder()
+  const [graph, setGraph] = useState("diagram");
+  const inputController = new InputController();
+
+  ControllerPanelHtmlBuilder.builder()
     .title("Node")
     .text("Node ID", node.id)
     .text("Node name", node.name)
-    .build();
+    .select("Change type", ["DRAFT", "LOAD_FILE"], inputController)
+    .build(panel);
+
+  inputController.get().addEventListener("change", (ev) => {
+    if (ev.target["value"] === "LOAD_FILE") {
+      /** @type {LoadFileNode} */
+      const newNode = {
+        id: node.id,
+        name: node.name,
+        type: "DATA",
+        dataType: "LOAD_FILE",
+        file: null,
+      };
+
+      setGraph({
+        nodes: [...graph.nodes.filter((v) => v.id !== node.id), newNode],
+      });
+      renderControllerPanel(newNode);
+    }
+  });
+}
+
+/**
+ * @param {DataNode} node
+ */
+function renderDataNodePanel(node) {
+  switch (node.dataType) {
+    case "LOAD_FILE":
+      const loadFileNode = /** @type {LoadFileNode} */ (node);
+      renderLoadFileNodePanel(loadFileNode);
+      break;
+  }
+}
+
+/**
+ * @param {LoadFileNode} node
+ */
+function renderLoadFileNodePanel(node) {
+  const panel = document.getElementById("controller-panel-body");
+  if (!panel) {
+    return;
+  }
+
+  const [graph, setGraph] = useState("diagram");
+  const fileController = new InputController();
+
+  ControllerPanelHtmlBuilder.builder()
+    .title("Node")
+    .text("Node ID", node.id)
+    .text("Node name", node.name)
+    .file("File", node.file, fileController)
+    .build(panel);
+
+  fileController.get().addEventListener("change", (ev) => {
+    const target = /** @type {HTMLInputElement} */ (ev.target);
+    if (target.files && target.files[0]) {
+      /** @type {LoadFileNode} */
+      const newNode = {
+        id: node.id,
+        name: node.name,
+        type: "DATA",
+        dataType: "LOAD_FILE",
+        file: target.files[0],
+      };
+
+      setGraph({
+        nodes: [...graph.nodes.filter((v) => v.id !== node.id), newNode],
+      });
+      renderControllerPanel(newNode);
+    }
+  });
 }
 
 /** @type {RenderControllerPanelFn} */
@@ -29,6 +103,10 @@ export function renderControllerPanel(node) {
     case "DRAFT":
       const draftNode = /** @type {DraftNode} */ (node);
       renderDraftNodePanel(draftNode);
+      break;
+    case "DATA":
+      const dataNode = /** @type {DataNode} */ (node);
+      renderDataNodePanel(dataNode);
       break;
   }
 }

--- a/static/canvas/js/controller-panel/input-controller.js
+++ b/static/canvas/js/controller-panel/input-controller.js
@@ -1,0 +1,29 @@
+export class InputController {
+  constructor() {
+    /** @type {string | null} */
+    this.id = null;
+  }
+
+  /**
+   * @param {string} id
+   */
+  attach(id) {
+    this.id = id;
+  }
+
+  /**
+   * @returns {HTMLInputElement}
+   */
+  get() {
+    if (!this.id) {
+      throw new Error("InputController is not attached to any element.");
+    }
+
+    const input = document.getElementById(this.id);
+    if (!input) {
+      throw new Error(`Element with id ${this.id} is not found.`);
+    }
+
+    return /** @type {HTMLInputElement} */ (input);
+  }
+}

--- a/static/canvas/types/controller-panel.d.ts
+++ b/static/canvas/types/controller-panel.d.ts
@@ -5,7 +5,9 @@ type RenderControllerPanelFn = StateChangeListener<"selectedNode">;
 
 type ControllerPanelHtmlElement =
   | ControllerPanelHtmlTitle
-  | ControllerPanelHtmlText;
+  | ControllerPanelHtmlText
+  | ControllerPanelHtmlSelect
+  | ControllerPanelHtmlFile;
 
 type ControllerPanelHtmlTitle = {
   type: "title";
@@ -16,4 +18,18 @@ type ControllerPanelHtmlText = {
   type: "text";
   label: string;
   value: string;
+};
+
+type ControllerPanelHtmlSelect = {
+  type: "select";
+  id: string;
+  label: string;
+  options: string[];
+};
+
+type ControllerPanelHtmlFile = {
+  type: "file";
+  id: string;
+  label: string;
+  file: File | null;
 };

--- a/static/canvas/types/nodes/data.d.ts
+++ b/static/canvas/types/nodes/data.d.ts
@@ -1,7 +1,11 @@
 /// <reference path="./common.d.ts" />
 
-type DataNode = BaseNode<"DATA">;
+type DataNodeType = "LOAD_FILE";
 
-type LoadFileNode = DataNode & {
-  filePath: string | null;
+type DataNode<TData extends DataNodeType = DataNodeType> = BaseNode<"DATA"> & {
+  dataType: TData;
+};
+
+type LoadFileNode = DataNode<"LOAD_FILE"> & {
+  file: File | null;
 };


### PR DESCRIPTION
- `DRAFT` 노드에서 노드 변경을 구현합니다.
- `LOAD_FILE` 노드에서 파일 선택을 구현합니다.
- 이에 따라 html builder에 `select`와 `file` 타입을 추가합니다.